### PR TITLE
test: Add missing abbreviation to faculty factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
   factory :faculty do
     sequence(:name) {|n| "Faculty #{n}"}
     sequence(:code) {|n| "#{Faker::Code.imei}#{n}"}
+    sequence(:abbreviation) {|n| "FAC#{n}"}
   end
 
   factory :department do


### PR DESCRIPTION
## Problem

Migration `20251005153029` added a NOT NULL `abbreviation` column to `faculties`, but `spec/factories.rb` was never updated. 25 of 154 specs fail on master with `PG::NotNullViolation`.

## Fix

One line: the faculty factory now sets a unique `abbreviation`.

## Testing

`bundle exec rspec spec/models spec/requests spec/controllers`: 154 examples, 0 failures (was 25 failures).

Prerequisite for the fixes in `plans/legacy-fixes.md` — every other PR's specs need a green baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)