### PR TITLE
chore: Update bundler version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,4 +472,4 @@ RUBY VERSION
    ruby 3.4.6p54
 
 BUNDLED WITH
-   2.3.24
+   2.7.2


### PR DESCRIPTION
## Problem

`BUNDLED WITH 2.3.24` (2022) predates Ruby 3.4.6 — fresh machines hit `Could not find 'bundler' (2.3.24)` on `bundle install`.

## Fix

`bundle update --bundler` — lockfile pin updated to 2.7.2, no gem changes. Heroku uses its own bundler and is unaffected.

Part of `plans/legacy-fixes.md` (PR 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)