### PR TITLE
fix: Fail boot when TZ env var is missing in production

### DIFF
--- a/config/initializers/000_config.rb
+++ b/config/initializers/000_config.rb
@@ -34,6 +34,14 @@ module Vaalit
     if Vaalit::Config::JWT_VOTER_SECRET == Vaalit::Config::JWT_SERVICE_USER_SECRET
       raise "JWT_VOTER_SECRET must differ from JWT_SERVICE_USER_SECRET"
     end
+
+    # Election opening hours are parsed with Time.parse and compared with
+    # Time.now, both of which depend on the server's TZ env var. A missing
+    # or wrong TZ silently shifts all voting times, so fail the boot instead.
+    # Enforced only in production: CI and dev machines may run in UTC.
+    if Rails.env.production? && ENV['TZ'] != 'Europe/Helsinki'
+      raise "TZ env var must be 'Europe/Helsinki' in production, got #{ENV['TZ'].inspect}"
+    end
   end
 
   module Haka


### PR DESCRIPTION
## Problem

Election opening hours rely on the server's `TZ` env var (`.env.example:15`): `RuntimeConfig` uses `Time.now`/`Time.parse` (`app/models/runtime_config.rb`) and `config/initializers/000_config.rb` parses `ELECTION_TERMINATES_AT` and `VOTE_SIGNIN_*` at boot. `config.time_zone` is not set, so a new environment without `TZ=Europe/Helsinki` silently shifts all voting times by 2-3 hours.

## Fix

Add a check to the existing `Vaalit::SanityCheck` module in `config/initializers/000_config.rb`: raise at boot when `ENV['TZ']` is missing or not `Europe/Helsinki`. Enforced only in production, since CI and dev machines may run in UTC. The working time-parsing logic is untouched.

## Testing

```
bundle exec rspec spec/models spec/requests spec/controllers
154 examples, 0 failures
```

(Test container runs in UTC, which is exactly why the guard is production-only.)

Part of plans/legacy-fixes.md (PR 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)