### PR TITLE
fix: Enforce voter uniqueness with database unique indexes

### DIFF
--- a/app/models/voter.rb
+++ b/app/models/voter.rb
@@ -15,7 +15,7 @@ class Voter < ActiveRecord::Base
 
   validates_uniqueness_of :student_number, allow_nil: true
 
-  validates_uniqueness_of :email, allow_nil: true
+  validates_uniqueness_of :email, allow_nil: true, case_sensitive: false
 
   validates_length_of :name,           :minimum => 4
   validates_length_of :ssn,            :minimum => 6

--- a/db/migrate/20260707064657_add_unique_indexes_to_voters.rb
+++ b/db/migrate/20260707064657_add_unique_indexes_to_voters.rb
@@ -1,0 +1,24 @@
+class AddUniqueIndexesToVoters < ActiveRecord::Migration[7.2]
+  # Enforce voter uniqueness at the database level. Haka sign-in resolves the
+  # voter by student_number, and email lookups are case-insensitive
+  # (Voter.find_by_email uses lower(email)), so the functional index both
+  # enforces uniqueness and makes the lookup indexable.
+  #
+  # NULLs stay allowed: Postgres treats NULLs as distinct in unique indexes,
+  # matching the model's allow_nil validations.
+  #
+  # This migration intentionally fails loudly if the database already
+  # contains duplicates: duplicates are cleaned up manually, and the database
+  # is recreated between elections.
+  #
+  # Note: ssn is deliberately NOT unique. Its uniqueness was removed in 2022
+  # (20221025075954_remove_uniquenes_on_voter_ssn.rb) because some students
+  # may have a placeholder ssn like "000000-0000". Voting right is verified
+  # by student_number.
+  def change
+    add_index :voters, :student_number, unique: true
+
+    remove_index :voters, name: "index_voters_on_email"
+    add_index :voters, "lower(email)", unique: true, name: "index_voters_on_lower_email"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_05_153029) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_07_064657) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,7 +106,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_05_153029) do
     t.integer "extent_of_studies"
     t.string "phone"
     t.integer "department_id"
-    t.index ["email"], name: "index_voters_on_email"
+    t.index "lower((email)::text)", name: "index_voters_on_lower_email", unique: true
+    t.index ["student_number"], name: "index_voters_on_student_number", unique: true
   end
 
   create_table "voting_rights", id: :serial, force: :cascade do |t|

--- a/spec/models/voter_spec.rb
+++ b/spec/models/voter_spec.rb
@@ -52,6 +52,25 @@ RSpec.describe Voter, type: :model do
     end
   end
 
+  describe "uniqueness" do
+
+    it "rejects a duplicate student number" do
+      existing = FactoryBot.create :voter
+      duplicate = FactoryBot.build :voter, student_number: existing.student_number
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:student_number]).to be_present
+    end
+
+    it "rejects the same email in different case" do
+      FactoryBot.create :voter, email: "pekka.purhonen@example.com"
+      duplicate = FactoryBot.build :voter, email: "Pekka.Purhonen@EXAMPLE.com"
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:email]).to be_present
+    end
+  end
+
   describe "import errors" do
     let(:existing_faculty_code) { 'H123' }
     let(:without_faculty) do


### PR DESCRIPTION
## Problem

Uniqueness of `student_number` and `email` is enforced only by model validations (`app/models/voter.rb`) — a race or a buggy import can create duplicates. Haka sign-in resolves the voter with `find_by_student_number!` (`app/models/haka/person.rb`), so a duplicate student number means the same student could end up with two voters and two voting rights. Additionally the email uniqueness validation is case-sensitive while the lookup (`Voter.find_by_email`) is case-insensitive, and the `lower(email)` lookup cannot use the existing plain btree index.

## Fix

- New migration adds `CREATE UNIQUE INDEX index_voters_on_student_number ON voters (student_number)` and `CREATE UNIQUE INDEX index_voters_on_lower_email ON voters (lower(email))`, and drops the old non-unique `index_voters_on_email` (the functional index replaces it — `find_by_email` is the only email lookup).
- NULLs stay allowed in both: Postgres treats NULLs as distinct in unique indexes, matching the existing `allow_nil: true` validations.
- The email uniqueness validation is now `case_sensitive: false`, matching the lookup, so a duplicate surfaces as a validation error instead of `ActiveRecord::RecordNotUnique`.

**Deploy note:** the migration intentionally fails loudly if the database already contains duplicates — duplicates are cleaned up manually, and the DB is recreated between elections.

**ssn is deliberately NOT unique:** its uniqueness was removed in 2022 (`db/migrate/20221025075954`) because some students may have a placeholder ssn like `000000-0000`. Voting right is verified by `student_number`.

## Testing

New model specs: duplicate `student_number` is rejected, and the same email in a different case is rejected by validation.

```
bundle exec rake db:create db:schema:load db:migrate
bundle exec rspec spec/models spec/requests spec/controllers
156 examples, 0 failures
```

(master baseline: 154 examples, 0 failures)

Part of plans/legacy-fixes.md (PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)