### PR TITLE
fix: Replace upgrade-fragile idioms in Election and PORO concern

### DIFF
--- a/app/concerns/extended_poro_behaviour.rb
+++ b/app/concerns/extended_poro_behaviour.rb
@@ -14,8 +14,6 @@ module ExtendedPoroBehaviour
   include ActiveModel::Validations
   include ActiveModel::Validations::Callbacks
 
-  include ActiveRecord::Callbacks
-
   included do
     def initialize(attributes = {})
       @errors = ActiveModel::Errors.new(self)

--- a/app/models/election.rb
+++ b/app/models/election.rb
@@ -20,7 +20,7 @@ class Election < ActiveRecord::Base
     return true if self.class.count == 0
     return true if self.class.count == 1 && self.class.first.id == self.id
 
-    @errors.add :type, "There can be only one Edari election at the same time."
+    errors.add :type, "There can be only one Edari election at the same time."
     return false
   end
 end


### PR DESCRIPTION
## Problem

Two spots work today but are liable to break on future Rails upgrades:

- `app/models/election.rb`: `unique_election?` called `@errors.add` directly, relying on the `@errors` ivar being initialized as a side effect of `valid?`.
- `app/concerns/extended_poro_behaviour.rb` included `ActiveRecord::Callbacks` into plain Ruby objects. The `before_validation` callback it was presumably there for is actually provided by `ActiveModel::Validations::Callbacks`, which is already included.

## Fix

- Use the public `errors.add` accessor in `Election#unique_election?`.
- Drop the `ActiveRecord::Callbacks` include from `ExtendedPoroBehaviour`. All includers were checked (SessionLink, SignInTokenProcessor, ImportedVoter, Haka::Person); only SessionLink uses a callback (`before_validation`), covered by `ActiveModel::Validations::Callbacks`.

## Testing

`bundle exec rspec spec/models spec/requests spec/controllers`: 154 examples, 0 failures.

Part of plans/legacy-fixes.md (PR 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)