### PR TITLE
fix: Narrow CastVote rescue and enqueue mail after commit

### DIFF
--- a/app/models/cast_vote.rb
+++ b/app/models/cast_vote.rb
@@ -9,7 +9,7 @@ class CastVote
   # Returns true IFF both VotingRight and ImmutableVote have been updated.
   # Return false or nil otherwise.
   def self.submit(election:, voter:, candidate:)
-    ActiveRecord::Base.transaction do
+    committed = ActiveRecord::Base.transaction do
       begin
         # Acquire a table level lock to table `voting_rights`.
         # Prevent a race condition where two simultaneous transactions
@@ -37,15 +37,25 @@ class CastVote
         ImmutableVote.create! election: election,
                               candidate: candidate
 
-        AfterVoteMailer.thank(voter).deliver_later if voter.email
-
-        return true
-      # Rollback any Exception in order to guarantee that no partial
+        true
+      # Rollback any StandardError in order to guarantee that no partial
       # update was persisted.
-      rescue Exception => e
+      rescue StandardError => e
         Rails.logger.error "[CastVote] Error: #{e}"
         raise ActiveRecord::Rollback
       end
     end
+
+    return false unless committed
+
+    # Enqueue outside the transaction: a failure here must not roll back
+    # a committed vote. A vote without a thank-you email is acceptable.
+    begin
+      AfterVoteMailer.thank(voter).deliver_later if voter.email
+    rescue StandardError => e
+      Rails.logger.error "[CastVote] Mailer enqueue failed: #{e}"
+    end
+
+    true
   end
 end

--- a/spec/models/cast_vote_spec.rb
+++ b/spec/models/cast_vote_spec.rb
@@ -45,10 +45,23 @@ RSpec.describe CastVote, type: :model do
 
       it "sends email about free coffee" do
         expect(AfterVoteMailer).to receive(:thank).with(@voter)
+          .and_return(double(deliver_later: true))
 
         CastVote.submit election: @election,
                         voter: @voter,
                         candidate: @candidate
+      end
+
+      it "does not lose the vote when mailer enqueue fails" do
+        allow(AfterVoteMailer).to receive(:thank).and_raise(StandardError)
+
+        return_value = CastVote.submit election: @election,
+                                       voter: @voter,
+                                       candidate: @candidate
+
+        expect(return_value).to be true
+        expect(ImmutableVote.count).to eq 1
+        expect(VotingRight.find(@voting_right.id)).to be_used
       end
 
       it "returns true when it succeeds" do
@@ -133,6 +146,15 @@ RSpec.describe CastVote, type: :model do
         @candidate.reload
         expect(@candidate.votes.count).to eq 0
         expect(ImmutableVote.count).to eq 0
+      end
+
+      it "does not send email" do
+        allow(ImmutableVote).to receive(:create!).and_raise(ActiveRecord::ActiveRecordError)
+        expect(AfterVoteMailer).not_to receive(:thank)
+
+        CastVote.submit election: @election,
+                        voter: @voter,
+                        candidate: @candidate
       end
 
       it "rollbacks on a generic RuntimeError" do


### PR DESCRIPTION
## Problem

`CastVote.submit` rescued `Exception`, which also catches signals and `SystemExit`, not just application errors. The `AfterVoteMailer` enqueue also sat inside the transaction and the table-wide `ACCESS EXCLUSIVE` lock on `voting_rights`: a mailer enqueue failure rolled back an otherwise successful vote, and the lock was held longer than needed.

## Fix

- `rescue Exception` narrowed to `rescue StandardError`.
- The mailer enqueue moved after the transaction and is sent only when the vote committed. An enqueue failure is logged and the vote is kept: a vote without a thank-you email is acceptable, a lost vote is not.

## Testing

New specs in `spec/models/cast_vote_spec.rb`: mailer is not enqueued when the vote fails; a mailer-enqueue failure does not lose the vote (returns true, `ImmutableVote` persisted, voting right used). Existing spec covers the mailer being enqueued on a successful vote.

`rspec spec/models spec/requests spec/controllers`: 156 examples, 0 failures (baseline on master: 154 examples, 0 failures).

Note: touches app/models/cast_vote.rb, overlaps with the candidate-election-validation PR — whichever merges second needs a trivial rebase.

Part of plans/legacy-fixes.md (PR 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)