### PR TITLE
fix: Keep student number out of info logs and Rollbar

### DIFF
--- a/app/controllers/haka/auth_controller.rb
+++ b/app/controllers/haka/auth_controller.rb
@@ -35,8 +35,10 @@ module Haka
       person = Person.new(response.attributes.multi(Vaalit::Haka::HAKA_STUDENT_NUMBER_FIELD))
 
       unless person.valid?
-        Rails.logger.info "No voting right for person '#{person.inspect}'"
-        Rollbar.info "No voting right present", person: person
+        # Person details (student number) are logged only at debug level.
+        Rails.logger.info "No voting right for person, failures: #{person.errors.attribute_names}"
+        Rails.logger.debug "No voting right for person '#{person.inspect}'"
+        Rollbar.info "No voting right present", failures: person.errors.attribute_names
 
         redirect_to frontend_error_path("no_voting_right")
         return


### PR DESCRIPTION
## Problem

`Haka::AuthController#consume` logged `person.inspect` at info level and sent the whole person object to Rollbar when a sign-in had no voting right. The person object carries the student number (personal data) inside its ActiveModel error message, and `filter_parameters` only masks request params — not interpolated log lines or Rollbar payloads. Production info logs and Rollbar therefore contained student numbers.

## Fix

- Info log now reports only the failure keys (`person.errors.attribute_names`, e.g. `[:voter]`), not the person dump.
- Rollbar receives the same failure keys instead of the person object.
- The detailed `person.inspect` line is kept at debug level for local troubleshooting.

Deliberate scope decision: the CSV import rake task `puts` output (including SSN on failure) is untouched — it is run manually and its output is needed for troubleshooting.

## Testing

```
docker run ... bundle exec rspec spec/models spec/requests spec/controllers
154 examples, 0 failures
```

Matches the master baseline (154 examples, 0 failures).

Part of plans/legacy-fixes.md (PR 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)