### PR TITLE
fix: Reject votes for candidates outside the election

### DIFF
--- a/app/models/cast_vote.rb
+++ b/app/models/cast_vote.rb
@@ -9,6 +9,9 @@ class CastVote
   # Returns true IFF both VotingRight and ImmutableVote have been updated.
   # Return false or nil otherwise.
   def self.submit(election:, voter:, candidate:)
+    # Refuse votes for candidates who do not belong to this election.
+    return false unless candidate.election == election
+
     committed = ActiveRecord::Base.transaction do
       begin
         # Acquire a table level lock to table `voting_rights`.

--- a/spec/models/cast_vote_spec.rb
+++ b/spec/models/cast_vote_spec.rb
@@ -73,6 +73,29 @@ RSpec.describe CastVote, type: :model do
       end
     end
 
+    context "when candidate belongs to another election" do
+
+      it "returns false and does not create a vote" do
+        # Election validates that only one election exists at a time,
+        # so bypass validation to set up a candidate in another election.
+        other_election = FactoryBot.build :election, :edari_election
+        other_election.save! validate: false
+        other_coalition = FactoryBot.create :coalition, election: other_election
+        other_alliance = FactoryBot.create :alliance,
+                                           coalition: other_coalition,
+                                           election: other_election
+        other_candidate = FactoryBot.create :candidate, alliance: other_alliance
+
+        result = CastVote.submit election: @election,
+                                 voter: @voter,
+                                 candidate: other_candidate
+
+        expect(result).to be false
+        expect(ImmutableVote.count).to eq 0
+        expect(@voter.voting_right.reload).not_to be_used
+      end
+    end
+
     context "when voting right has already been used" do
 
       it "returns false when voting right has already been used" do


### PR DESCRIPTION
## Problem

The vote endpoint (`app/api/vaalit/elections.rb`) does `Candidate.find(params[:candidate_id])` without binding the candidate to the election being voted in, and `immutable_votes` has no DB constraint tying candidate and election together either. Harmless in today's single-election setup, but nothing enforces it.

## Fix

One guard in `CastVote.submit` — the single path all votes go through: return `false` unless `candidate.election == election` (Candidate reaches its Election through its Alliance via `has_one :election, through: :alliance`). A mismatched vote creates no `ImmutableVote` row and leaves the voting right unused.

## Testing

New spec: a vote for a candidate of a different election returns `false`, creates no vote row, and does not consume the voting right. (Election validates that only one election exists, so the second election is set up with `save! validate: false`.)

```
bundle exec rspec spec/models spec/requests spec/controllers
155 examples, 0 failures
```

(Baseline on master: 154 examples, 0 failures.)

Note: touches app/models/cast_vote.rb, overlaps with the CastVote rescue/mailer PR — whichever merges second needs a trivial rebase.

Part of plans/legacy-fixes.md (PR 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)