### PR TITLE
fix: Reject session JWTs at the sign-in token exchange

### DIFF
--- a/app/models/session_token.rb
+++ b/app/models/session_token.rb
@@ -27,7 +27,8 @@ class SessionToken
   def jwt
     payload = {
       voter_id: @user.voter.id,
-      email: @user.voter.email
+      email: @user.voter.email,
+      typ: 'session'
     }
 
     JsonWebToken.encode payload,
@@ -37,7 +38,7 @@ class SessionToken
 
   # Short-lived JWT which is used in the sign in and exchanged for a session jwt.
   def ephemeral_jwt(lifetime = Vaalit::Config::SIGN_IN_JWT_EXPIRY_SECONDS)
-    payload = { voter_id: @user.voter.id }
+    payload = { voter_id: @user.voter.id, typ: 'signin' }
     expiry = lifetime.from_now
 
     JsonWebToken.encode payload,

--- a/app/models/sign_in_token_processor.rb
+++ b/app/models/sign_in_token_processor.rb
@@ -46,13 +46,16 @@ class SignInTokenProcessor
     # Retrieve email from the payload of the JWT token which was given in
     # the sign-in link.
     #
+    # Only sign-in tokens (typ "signin") are accepted, so that a long-lived
+    # session JWT cannot be exchanged for a fresh session.
+    #
     # Format:
-    # [{"voter_id"=>1}, {"typ"=>"JWT", "alg"=>"HS256"}]
+    # [{"voter_id"=>1, "typ"=>"signin"}, {"typ"=>"JWT", "alg"=>"HS256"}]
     def read_token(jwt)
       data = JsonWebToken.decode jwt,
                                  Vaalit::Config::JWT_VOTER_SECRET
 
-      if data.nil?
+      if data.nil? || data.first["typ"] != "signin"
         errors.add(:source_token, "Invalid source JWT token in the sign in link")
         return
       end

--- a/spec/models/session_token_spec.rb
+++ b/spec/models/session_token_spec.rb
@@ -25,5 +25,19 @@ RSpec.describe SessionToken, type: :model do
       expect(@token.user.voter.id).to eq(@voter_id)
     end
 
+    it "marks the session JWT with typ session" do
+      payload = JsonWebToken.decode(@token.jwt, Vaalit::Config::JWT_VOTER_SECRET).first
+
+      expect(payload["typ"]).to eq("session")
+      expect(payload["voter_id"]).to eq(@voter_id)
+    end
+
+    it "marks the ephemeral JWT with typ signin" do
+      payload = JsonWebToken.decode(@token.ephemeral_jwt, Vaalit::Config::JWT_VOTER_SECRET).first
+
+      expect(payload["typ"]).to eq("signin")
+      expect(payload["voter_id"]).to eq(@voter_id)
+    end
+
   end
 end

--- a/spec/models/sign_in_token_processor_spec.rb
+++ b/spec/models/sign_in_token_processor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SignInTokenProcessor, type: :model do
     before do
       @example_email = "email@example.com"
       @voter_id = 4321
-      @jwt = JsonWebToken.encode({email: @example_email},
+      @jwt = JsonWebToken.encode({email: @example_email, typ: "signin"},
                                  Vaalit::Config::JWT_VOTER_SECRET)
 
       voter = FactoryBot.build :voter, {
@@ -23,6 +23,19 @@ RSpec.describe SignInTokenProcessor, type: :model do
       expect(processor).to be_valid
       expect(processor.session_token.user.voter.email).to eq(@example_email)
       expect(processor.session_token.user.voter.id).to eq(@voter_id)
+    end
+
+  end
+
+  context "session JWT used as source token" do
+    it "will fail validations" do
+      voter = FactoryBot.build :voter, email: "email@example.com", id: 4321
+      session_jwt = SessionToken.new(voter).jwt
+
+      processor = SignInTokenProcessor.new session_jwt
+
+      expect(processor).not_to be_valid
+      expect(processor.errors[:source_token].first).to eq "Invalid source JWT token in the sign in link"
     end
 
   end

--- a/spec/requests/api/session_spec.rb
+++ b/spec/requests/api/session_spec.rb
@@ -19,10 +19,20 @@ describe Vaalit::Session do
     end
 
     it 'requires a valid user in the token' do
-      token = JsonWebToken.encode({email: "inexistant.user@example.com"},
+      token = JsonWebToken.encode({email: "inexistant.user@example.com", typ: "signin"},
                                   Vaalit::Config::JWT_VOTER_SECRET)
 
       post "/api/sessions?token=#{token}"
+
+      expect(response).not_to be_successful
+      expect(json["error"]).to eq "Invalid sign-in token"
+    end
+
+    it 'rejects a session JWT used as a sign in token' do
+      voter = FactoryBot.build :voter, id: 123, email: "user@example.com"
+      token = SessionToken.new(voter).jwt
+
+      post "/api/sessions?token=#{URI.encode_www_form_component(token)}"
 
       expect(response).not_to be_successful
       expect(json["error"]).to eq "Invalid sign-in token"
@@ -34,7 +44,7 @@ describe Vaalit::Session do
       voter = FactoryBot.build :voter, id: voter_id, email: email
       allow(Voter).to receive(:find).once.and_return(voter)
 
-      token = JsonWebToken.encode({voter_id: voter_id},
+      token = JsonWebToken.encode({voter_id: voter_id, typ: "signin"},
                                   Vaalit::Config::JWT_VOTER_SECRET)
 
       post "/api/sessions?token=#{token}"


### PR DESCRIPTION
## Problem

Both token kinds are signed with the same secret and the same payload shape (`app/models/session_token.rb`), so a long-lived session JWT is accepted by `POST /api/sessions` as a "sign-in token". A holder of a session JWT can renew their session indefinitely while sign-in is open. The class comment promises independent expiries for the two tokens, but nothing actually separates them.

## Fix

- `SessionToken#ephemeral_jwt` adds `typ: 'signin'` to the payload; `SessionToken#jwt` adds `typ: 'session'`.
- `SignInTokenProcessor#read_token` accepts only payloads with `typ == "signin"`; anything else fails validation and the exchange returns 403 as before.
- Specs: payload `typ` claims asserted in `session_token_spec.rb`; session-JWT rejection proven at both the processor (`sign_in_token_processor_spec.rb`) and the `POST /api/sessions` request level (`spec/requests/api/session_spec.rb`).

The session-JWT decode path (`app/api/vaalit/jwt_helpers.rb`) only reads `voter_id`, so the new claim does not affect API access with existing flows.

## Deploy note

Sign-in tokens minted before the deploy lack the `typ` claim, so this invalidates in-flight emailed sign-in links and Haka redirects at the exchange step. Deploy between elections.

## Testing

`bundle exec rspec spec/models spec/requests spec/controllers`: 158 examples, 0 failures (baseline on master: 154 examples, 0 failures; 4 new examples).

Note: touches app/models/session_token.rb, overlaps with the dead-validation-code PR — whichever merges second needs a trivial rebase.

Part of plans/legacy-fixes.md (PR 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)