### PR TITLE
fix: Make SessionToken validation meaningful, drop bogus option

### DIFF
--- a/app/models/session_token.rb
+++ b/app/models/session_token.rb
@@ -60,7 +60,7 @@ class SessionToken
   begin
 
     def validate
-      not user.blank?
+      user.present? && user.voter.present?
     end
 
   end

--- a/app/models/voting_right.rb
+++ b/app/models/voting_right.rb
@@ -7,7 +7,6 @@ class VotingRight < ApplicationRecord
   belongs_to :election
 
   validates_uniqueness_of :voter,
-                            null: false,
                             scope: :election_id
 
   validates_presence_of :election_id,

--- a/spec/models/session_token_spec.rb
+++ b/spec/models/session_token_spec.rb
@@ -39,5 +39,9 @@ RSpec.describe SessionToken, type: :model do
       expect(payload["voter_id"]).to eq(@voter_id)
     end
 
+    it "is not valid without a voter" do
+      expect(SessionToken.new(nil)).not_to be_valid
+    end
+
   end
 end

--- a/spec/models/voting_right_spec.rb
+++ b/spec/models/voting_right_spec.rb
@@ -30,5 +30,12 @@ RSpec.describe VotingRight, type: :model do
 
     end
 
+    it "is not valid without a voter" do
+      voting_right = VotingRight.new election: @election
+
+      expect(voting_right).not_to be_valid
+      expect(voting_right.errors[:voter_id]).to include "can't be blank"
+    end
+
   end
 end


### PR DESCRIPTION
## Problem

- `SessionToken#validate` checked `not user.blank?`, but `User` is a plain Ruby object and never `blank?`, so `valid?` always returned true regardless of state.
- `VotingRight` passed `null: false` to `validates_uniqueness_of`, which is not a valid option for that validator and was silently ignored.

## Fix

- `SessionToken#validate` now checks `user.present? && user.voter.present?`, so `valid?` actually verifies the token wraps a voter. All legitimate call sites (`SignInTokenProcessor`, `SessionLink`, `Haka::AuthController`) construct `SessionToken` with a real `Voter`, so they keep working.
- Removed the bogus `null: false` option from `VotingRight`; presence is already enforced by `validates_presence_of`.
- Added specs: `SessionToken.new(nil)` is not valid, and `VotingRight` without a voter fails presence validation.

## Testing

`bundle exec rspec spec/models spec/requests spec/controllers` (dockerized ruby:3.4.6 + postgres): **156 examples, 0 failures** (baseline on master: 154 examples, 0 failures; +2 new examples).

Note: touches app/models/session_token.rb, overlaps with the sign-in JWT typ PR — whichever merges second needs a trivial rebase.

Part of plans/legacy-fixes.md (PR 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)