### PR TITLE
fix: Return 404/401 instead of 500 for missing records in API

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -2,6 +2,11 @@ class Api < Grape::API
   prefix 'api'
   format :json
 
+  rescue_from ActiveRecord::RecordNotFound do |exception|
+    Rails.logger.info "Record not found: #{exception.message}"
+    error!({ message: 'Not found' }, :not_found)
+  end
+
   helpers Vaalit::JwtHelpers
 
   helpers do

--- a/app/api/vaalit/jwt_helpers.rb
+++ b/app/api/vaalit/jwt_helpers.rb
@@ -6,7 +6,12 @@ module Vaalit
       decoded_token = decode_jwt(headers, Vaalit::Config::JWT_VOTER_SECRET)
 
       if decoded_token
-        Voter.find decoded_token["voter_id"]
+        begin
+          Voter.find decoded_token["voter_id"]
+        rescue ActiveRecord::RecordNotFound
+          Rails.logger.info "Voter #{decoded_token['voter_id']} from valid jwt token does not exist anymore"
+          false
+        end
       else
         Rails.logger.debug "Couldn't verify voter_id from jwt token (voter_id doesn't exist or token has expired)"
         return false

--- a/spec/requests/api/edari/authentication_spec.rb
+++ b/spec/requests/api/edari/authentication_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Vaalit::Edari::EdariApi do
+
+  context 'with a valid JWT for a deleted voter' do
+    before do
+      voter = FactoryBot.create :voter
+      token = JsonWebToken.encode({ voter_id: voter.id },
+                                  Vaalit::Config::JWT_VOTER_SECRET)
+      voter.destroy!
+
+      get "/api/elections/1/candidates",
+          headers: { "Authorization": "Bearer #{token}" }
+    end
+
+    it 'returns unauthorized' do
+      expect(response).to have_http_status(:unauthorized)
+      expect(json["message"]).to eq "Unauthorized"
+    end
+  end
+end

--- a/spec/requests/api/public/voting_percentage_spec.rb
+++ b/spec/requests/api/public/voting_percentage_spec.rb
@@ -6,6 +6,17 @@ describe Vaalit::Public do
     @election = FactoryBot.create(:election)
   end
 
+  context 'when election does not exist' do
+    before do
+      get "/api/public/elections/#{@election.id + 1}/voting_percentage"
+    end
+
+    it 'returns not found' do
+      expect(response).to have_http_status(:not_found)
+      expect(json["message"]).to eq "Not found"
+    end
+  end
+
   context 'when voting has not started' do
     before do
       get "/api/public/elections/#{@election.id}/voting_percentage"


### PR DESCRIPTION
## Problem

The Grape stack has no `rescue_from`, so `ActiveRecord::RecordNotFound` bubbles up as HTTP 500 and Rollbar noise:

- `Election.find` on public endpoints (`app/api/vaalit/public/voting_percentage.rb`) returns 500 for unknown election ids.
- `Voter.find` in `app/api/vaalit/jwt_helpers.rb` raises when a voter has been deleted but its JWT is still valid, returning 500 instead of 401.

## Fix

- Add `rescue_from ActiveRecord::RecordNotFound` in `Api` (app/api/api.rb) responding 404 with a JSON message.
- `current_voter_user` rescues `RecordNotFound` and returns `false`, so the existing `before` blocks respond 401 Unauthorized.

## Testing

Request specs added: unknown election id on a public endpoint returns 404 JSON; a valid JWT for a deleted voter returns 401.

```
bundle exec rspec spec/models spec/requests spec/controllers
156 examples, 0 failures
```

(Baseline on master: 154 examples, 0 failures.)

Part of plans/legacy-fixes.md (PR 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)