### PR TITLE
fix: Restrict CORS origins to configured frontend origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,8 +132,9 @@ SITE_ADDRESS=http://localhost:3000
 SITE_DOMAIN=vaalit.hyy.fi
 
 # Comma-separated list of origins allowed by CORS.
+# Development: frontend dev server (9000), rails server (3000), ssl-forwarded rails server (3001)
 # Production: CORS_ALLOWED_ORIGINS=https://vaalit.hyy.fi
-CORS_ALLOWED_ORIGINS=http://localhost:9000
+CORS_ALLOWED_ORIGINS=http://localhost:9000,http://localhost:3000,https://localhost:3001
 
 # Since Rails 7.2 the FRONTEND_API_BASE_URL must not mix between http://localhost:3000 here and
 # https://localhost.enemy.fi:3001 from Haka or Safari will fail with a CORS error. Chrome works though!

--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,10 @@ HAKA_STUDENT_NUMBER_KEY="urn:schac:personalUniqueCode:fi:yliopisto.fi"
 SITE_ADDRESS=http://localhost:3000
 SITE_DOMAIN=vaalit.hyy.fi
 
+# Comma-separated list of origins allowed by CORS.
+# Production: CORS_ALLOWED_ORIGINS=https://vaalit.hyy.fi
+CORS_ALLOWED_ORIGINS=http://localhost:9000
+
 # Since Rails 7.2 the FRONTEND_API_BASE_URL must not mix between http://localhost:3000 here and
 # https://localhost.enemy.fi:3001 from Haka or Safari will fail with a CORS error. Chrome works though!
 FRONTEND_API_BASE_URL="https://localhost.enemy.fi:3001/api"

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ OpenSSL::X509::Certificate.new cert
   * SECRET_KEY_BASE (`rails secret`)
   * JWT_VOTER_SECRET (`rails secret`)
   * JWT_SERVICE_USER_SECRET (`rails secret`)
+  * CORS_ALLOWED_ORIGINS (production: `https://vaalit.hyy.fi`)
 
 * Provision Heroku process for both "web" and "worker"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,13 +20,6 @@ Bundler.require(*Rails.groups)
 
 module HyyVotingApi
   class Application < Rails::Application
-    config.middleware.use Rack::Cors do
-      allow do
-        origins '*'
-        resource '*', :headers => :any, :methods => [:get, :post, :put, :delete, :options]
-      end
-    end
-
     config.active_support.cache_format_version = 7.1
 
     config.active_job.queue_adapter = :delayed_job

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,9 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV.fetch('CORS_ALLOWED_ORIGINS').split(',').map(&:strip)
+    resource '*', :headers => :any, :methods => [:get, :post, :put, :delete, :options]
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
   factory :faculty do
     sequence(:name) {|n| "Faculty #{n}"}
     sequence(:code) {|n| "#{Faker::Code.imei}#{n}"}
+    sequence(:abbreviation) {|n| "FAC#{n}"}
   end
 
   factory :department do


### PR DESCRIPTION
## Problem

CORS was configured in two places: `config/application.rb` allowed requests from **any origin** (`origins '*'`), while `config/initializers/cors.rb` was a dead comment block.

## Fix

- Move the Rack::Cors middleware config into `config/initializers/cors.rb` (inserted at position 0, verified via `rails middleware` that Rack::Cors is first in the stack), deleting the dead comments.
- Read allowed origins from the new `CORS_ALLOWED_ORIGINS` env var (comma-separated). The app fails fast at boot with a `KeyError` if the variable is missing, consistent with `config/initializers/000_config.rb` style.
- Document the variable in `.env.example` and the README env var list.

## Deploy note

Set `CORS_ALLOWED_ORIGINS` **before** deploying this change or the app will not boot:
- production: `CORS_ALLOWED_ORIGINS=https://vaalit.hyy.fi`
- development: `CORS_ALLOWED_ORIGINS=http://localhost:9000,http://localhost:3000,https://localhost:3001`

## Testing

- `bundle exec rspec spec/models spec/requests spec/controllers`: **154 examples, 0 failures** (matches master baseline).
- `rails middleware` shows `use Rack::Cors` first in the stack.
- Boot without the variable raises `KeyError: key not found: "CORS_ALLOWED_ORIGINS"` from the initializer.

Note: touches config/application.rb, overlaps with the basic-auth PR — whichever merges second needs a trivial rebase.

Part of plans/legacy-fixes.md (PR 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
