### PR TITLE
chore: Add Docker setup for local development and tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+log
+tmp
+plans
+.claude
+.vite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Local development and test runs only — production runs on Heroku.
+FROM ruby:3.4.6-slim
+
+# build-essential/patch/zlib1g-dev/liblzma-dev: nokogiri builds from source
+# (Gemfile.lock PLATFORMS is "ruby" only); libpq-dev: pg gem; libyaml-dev: psych.
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+      build-essential patch zlib1g-dev liblzma-dev libpq-dev libyaml-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Match BUNDLED WITH in Gemfile.lock.
+COPY Gemfile Gemfile.lock ./
+RUN gem install bundler -v 2.7.2 && bundle install
+
+COPY . .
+
+# Haka-test example certs, referenced as $(cat cert/haka-test/...) in .env / .env.test
+RUN [ -d cert/haka-test ] || { mkdir -p cert && cp -r doc/examples/haka-test cert/; }
+
+EXPOSE 3000
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,41 @@
+# Development:
+#   docker compose up                          # API at http://localhost:3000
+#   docker compose run --rm api rake db:runts  # recreate db with seed data
+#
+# Test suite:
+#   docker compose run --rm -e RAILS_ENV=test \
+#     -e DATABASE_URL=postgres://postgres:postgres@db/hyy-voting-api_test \
+#     api sh -c 'bin/rails db:create db:schema:load && bundle exec rspec'
+#
+# App code is baked into the image — rebuild after code changes:
+#   docker compose build api
+services:
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 2s
+      retries: 15
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  api:
+    build: .
+    # Everything else comes from .env / .env.test via dotenv inside the
+    # container; DATABASE_URL overrides the socket-based database.yml.
+    environment:
+      RAILS_ENV: development
+      DATABASE_URL: postgres://postgres:postgres@db/hyy-voting-api_development
+      # DatabaseCleaner refuses non-localhost DATABASE_URLs; "db" is our own
+      # compose service, not a remote database. Only used by the test suite.
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary

Adds a `Dockerfile`, `compose.yaml` and `.dockerignore` so the app and the spec suite run without a local Ruby install (README's RVM setup remains valid but is no longer required).

- `docker compose up` — API at http://localhost:3000 (postgres:17 with a healthcheck and a persistent volume)
- `docker compose run --rm api rake db:runts` — recreate the development database with seed data
- Test suite (also documented in compose.yaml comments):
  ```
  docker compose run --rm -e RAILS_ENV=test \
    -e DATABASE_URL=postgres://postgres:postgres@db/hyy-voting-api_test \
    api sh -c 'bin/rails db:create db:schema:load && bundle exec rspec'
  ```

## Implementation notes

- nokogiri and psych build from source (`Gemfile.lock` PLATFORMS is "ruby" only), hence the `build-essential patch zlib1g-dev liblzma-dev libpq-dev libyaml-dev` apt set.
- Haka-test example certs are copied to `cert/haka-test/` in the image, matching the `$(cat cert/haka-test/...)` references in `.env` / `.env.test`.
- `DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true` is set on the service: DatabaseCleaner's safeguard rejects any non-localhost `DATABASE_URL`, and the `db` host is our own compose Postgres, not a remote database. Only the test suite reads it.
- Bundler is pinned to 2.7.2 to match `BUNDLED WITH` in `Gemfile.lock`.
- Reminder: `.env` needs `CORS_ALLOWED_ORIGINS` since #17 or boot fails (values in `.env.example`).

## Verification

Ran in the container: full suite passes — **167 examples, 0 failures** — and after `rake db:runts` the API answers: `/api/pling` → `{"pling":"plong"}`, `/_environment.js` → 200, unknown election id → 404 (#16 behaving live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)