### PR TITLE
fix: Return 422 instead of 500 when a vote is rejected

### DIFF
--- a/app/api/vaalit/elections.rb
+++ b/app/api/vaalit/elections.rb
@@ -62,7 +62,7 @@ module Vaalit
               if result
                 present @current_user.voting_right, with: Entities::VotingRight
               else
-                Rails.logger.warn "Failed submitting vote for #{current_user.id}"
+                Rails.logger.warn "Failed submitting vote for #{@current_user.id}"
                 error!(
                   {
                     voting_right: @current_user.voting_right,

--- a/spec/requests/api/edari/elections_spec.rb
+++ b/spec/requests/api/edari/elections_spec.rb
@@ -3,6 +3,67 @@ require "cancan/matchers"
 
 describe Vaalit::Elections do
 
+  describe "POST /api/elections/:election_id/vote" do
+    before do
+      allow(RuntimeConfig).to receive(:voting_active?).and_return(true)
+
+      @election = FactoryBot.create :election, :edari_election
+      @coalition = FactoryBot.create :coalition, election: @election
+      @alliance = FactoryBot.create :alliance,
+                                    coalition: @coalition,
+                                    election: @election
+      @candidate = FactoryBot.create :candidate, alliance: @alliance
+      @voter = FactoryBot.create :voter, :with_voting_right, election: @election
+
+      token = JsonWebToken.encode({ voter_id: @voter.id },
+                                  Vaalit::Config::JWT_VOTER_SECRET)
+      @headers = { "Authorization": "Bearer #{token}" }
+    end
+
+    def cast_vote(candidate_id)
+      post "/api/elections/#{@election.id}/vote",
+           params: { candidate_id: candidate_id },
+           headers: @headers
+    end
+
+    it 'casts the vote and marks the voting right used' do
+      cast_vote @candidate.id
+
+      expect(response).to have_http_status(:created)
+      expect(json["used"]).to eq true
+      expect(@voter.voting_right.reload).to be_used
+      expect(ImmutableVote.count).to eq 1
+    end
+
+    it 'returns 422 with the voting right when the vote is submitted twice' do
+      cast_vote @candidate.id
+      cast_vote @candidate.id
+
+      expect(response).to have_http_status(422)
+      expect(json["message"]).to eq "Vote could not be submitted"
+      expect(json["voting_right"]["used"]).to eq true
+      expect(ImmutableVote.count).to eq 1
+    end
+
+    it 'returns 422 when the candidate belongs to another election' do
+      # Election validates that only one election exists at a time,
+      # so bypass validation to set up a candidate in another election.
+      other_election = FactoryBot.build :election, :edari_election
+      other_election.save! validate: false
+      other_coalition = FactoryBot.create :coalition, election: other_election
+      other_alliance = FactoryBot.create :alliance,
+                                         coalition: other_coalition,
+                                         election: other_election
+      other_candidate = FactoryBot.create :candidate, alliance: other_alliance
+
+      cast_vote other_candidate.id
+
+      expect(response).to have_http_status(422)
+      expect(ImmutableVote.count).to eq 0
+      expect(@voter.voting_right.reload).not_to be_used
+    end
+  end
+
   describe "authorization" do
     subject(:ability) { Ability.new(user) }
     let(:user) { nil }


### PR DESCRIPTION
## Problem

`app/api/vaalit/elections.rb` logs `current_user.id` in the failed-vote branch, but nothing in the Grape stack defines `current_user` — only the `@current_user` ivar is ever set (`edari_api.rb`). So whenever `CastVote.submit` returns false — double-submitted vote (the everyday case), voter without a voting right, or candidate outside the election — the endpoint raised `NoMethodError` → **500** + Rollbar noise, and the intended **422** body with the voting-right payload was never sent.

The line dates from 2015 (`59cd91d`) and survived because the failure path had zero request-spec coverage.

## Fix

`current_user.id` → `@current_user.id`. One word.

## Tests

New request specs for `POST /api/elections/:id/vote` (the file previously contained only CanCan ability matchers, no HTTP calls):
- happy path: valid voter + candidate → 201, voting right marked used
- double vote → 422 with `voting_right` in the body (pins this fix — failed with `NoMethodError` before it)
- candidate from another election → 422 (also failed with `NoMethodError` before)

Full suite: 170 examples, 0 failures.

Finding 1 + 2 of `plans/re-review-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)