### PR TITLE
fix: Mark rake-generated voter JWTs with the signin typ claim

### DIFF
--- a/lib/tasks/jwt/generate.rake
+++ b/lib/tasks/jwt/generate.rake
@@ -67,7 +67,8 @@ namespace :jwt do
     desc 'generate a JWT token for Frontend access'
     task :generate, [:voter_id, :expiry_hours] => :environment do
       voter_id = ENV['voter_id'] || 1
-      payload = { voter_id: voter_id.to_i }
+      # SignInTokenProcessor only accepts tokens with typ "signin".
+      payload = { voter_id: voter_id.to_i, typ: 'signin' }
 
       generate payload,
                Vaalit::Config::JWT_VOTER_SECRET,


### PR DESCRIPTION
## Problem

`rake jwt:voter:generate` builds the voter token payload without `typ: 'signin'`. Since #14, `SignInTokenProcessor#read_token` requires that claim, so the sign-in links the task prints are rejected at the exchange. The README's "example user without Haka-test" workflow relies on this task. Dev tooling only — production sign-in paths (email link, Haka) set the claim correctly.

## Fix

Add `typ: 'signin'` to the payload in the `jwt:voter:generate` task.

Verified: a task-generated token now passes `SignInTokenProcessor`'s typ check; a token without the claim is still rejected.

Finding 3 of `plans/re-review-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)