### PR TITLE
chore: Run the spec suite in GitHub Actions on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: hyy-voting-api_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: hyy-voting-api_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      RACK_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/hyy-voting-api_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Vaalit::Config fetches its settings from ENV at boot; .env.example
+      # provides working values for the test suite via dotenv. Job-level env
+      # above wins over the file (dotenv does not override existing vars).
+      - name: Provide env vars from .env.example
+        run: cp .env.example .env
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Load database schema
+        run: bundle exec rails db:schema:load
+
+      - name: Run specs
+        run: bundle exec rspec


### PR DESCRIPTION
## Problem

GitHub runs only Dependabot; the spec suite runs solely on the maintainer's machine. The 13 recently merged PRs were verified locally only. A CI run on every PR would have been the second line of defense for findings 1–3 of `plans/re-review-findings.md`.

## Fix

Minimal GitHub Actions workflow:
- postgres:16 service container
- Ruby via `ruby/setup-ruby` (reads `.ruby-version`), `bundler-cache: true`
- `db:schema:load`, `bundle exec rspec`
- test env vars from `.env.example` (`Vaalit::Config` ENV fetches need them); job-level `RAILS_ENV=test` and `DATABASE_URL` win over the file since dotenv never overrides existing vars

The workflow runs on this PR itself, so green checks below = verified.

Finding 6 of `plans/re-review-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)