### PR TITLE
fix: Require session typ claim on voter Bearer tokens

### DIFF
--- a/app/api/vaalit/jwt_helpers.rb
+++ b/app/api/vaalit/jwt_helpers.rb
@@ -5,6 +5,14 @@ module Vaalit
     def current_voter_user(headers)
       decoded_token = decode_jwt(headers, Vaalit::Config::JWT_VOTER_SECRET)
 
+      # Only long-lived session tokens (typ "session") grant API access.
+      # An ephemeral sign-in token must be exchanged for a session token
+      # at POST /api/sessions first.
+      if decoded_token && decoded_token["typ"] != "session"
+        Rails.logger.info "Rejected Bearer jwt with typ #{decoded_token['typ'].inspect}"
+        return false
+      end
+
       if decoded_token
         begin
           Voter.find decoded_token["voter_id"]

--- a/spec/requests/api/edari/authentication_spec.rb
+++ b/spec/requests/api/edari/authentication_spec.rb
@@ -5,7 +5,7 @@ describe Vaalit::Edari::EdariApi do
   context 'with a valid JWT for a deleted voter' do
     before do
       voter = FactoryBot.create :voter
-      token = JsonWebToken.encode({ voter_id: voter.id },
+      token = JsonWebToken.encode({ voter_id: voter.id, typ: 'session' },
                                   Vaalit::Config::JWT_VOTER_SECRET)
       voter.destroy!
 
@@ -16,6 +16,39 @@ describe Vaalit::Edari::EdariApi do
     it 'returns unauthorized' do
       expect(response).to have_http_status(:unauthorized)
       expect(json["message"]).to eq "Unauthorized"
+    end
+  end
+
+  context 'with a sign-in JWT used as a Bearer token' do
+    before do
+      voter = FactoryBot.create :voter
+      token = SessionToken.new(voter).ephemeral_jwt
+
+      get "/api/elections/1/candidates",
+          headers: { "Authorization": "Bearer #{token}" }
+    end
+
+    it 'returns unauthorized' do
+      expect(response).to have_http_status(:unauthorized)
+      expect(json["message"]).to eq "Unauthorized"
+    end
+  end
+
+  context 'with a session JWT issued by SessionToken' do
+    before do
+      allow(RuntimeConfig).to receive(:voting_active?).and_return(true)
+
+      voter = FactoryBot.create :voter
+      token = SessionToken.new(voter).jwt
+
+      get "/api/elections/1/candidates",
+          headers: { "Authorization": "Bearer #{token}" }
+    end
+
+    it 'passes authentication' do
+      # 404 for the nonexistent election proves the request got past
+      # both the typ check and the ability check.
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/api/edari/elections_spec.rb
+++ b/spec/requests/api/edari/elections_spec.rb
@@ -15,7 +15,7 @@ describe Vaalit::Elections do
       @candidate = FactoryBot.create :candidate, alliance: @alliance
       @voter = FactoryBot.create :voter, :with_voting_right, election: @election
 
-      token = JsonWebToken.encode({ voter_id: @voter.id },
+      token = JsonWebToken.encode({ voter_id: @voter.id, typ: 'session' },
                                   Vaalit::Config::JWT_VOTER_SECRET)
       @headers = { "Authorization": "Bearer #{token}" }
     end


### PR DESCRIPTION
Implements finding 4 from the 2026-07-09 re-review.

## Problem

`current_voter_user` accepted any JWT signed with the voter secret as a
Bearer API token. Since PR #14 the two token kinds are distinguished by a
`typ` claim, but only the sign-in exchange enforced it — so a short-lived
sign-in token (emailed link, Haka redirect, `rake jwt:voter:generate`)
worked directly as an API session token during its lifetime.

## Fix

`current_voter_user` rejects any voter JWT whose `typ` is not `session`.
Sign-in tokens must be exchanged at `POST /api/sessions` first.

Specs: sign-in JWT as Bearer → 401; `SessionToken#jwt` still authenticates
end to end. Existing hand-rolled spec tokens now carry `typ: 'session'`.

## Deploy note

Session tokens issued before PR #14 carry no `typ` claim and will be
signed out by this change. Deploy between elections, like #14.

Full suite in Docker: 172 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)