### PR TITLE
fix: Pull postgres CI image from public ECR Docker Hub mirror

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,10 @@ jobs:
 
     services:
       postgres:
-        image: postgres:18
+        # Docker Hub mirror on AWS public ECR; avoids Docker Hub outages
+        # and anonymous-pull rate limits (master run 29087579964 failed on
+        # a Docker Hub 500 during "docker pull postgres:18").
+        image: public.ecr.aws/docker/library/postgres:18
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: hyy-voting-api_test


### PR DESCRIPTION
## Why

Master CI run [29087579964](https://github.com/hyy-vaalit/voting-api/actions/runs/29087579964/job/86344872808) failed before any step ran: Docker Hub answered `docker pull postgres:18` with **HTTP 500 Internal Server Error** on all three retries while starting the postgres service container. Nothing in the code was at fault — the previous run of the same workflow passed 30 minutes earlier.

## Fix

Pull the postgres service image from `public.ecr.aws/docker/library/postgres:18`, the AWS-hosted mirror of the official Docker Hub image. Same image, but CI no longer depends on Docker Hub availability or its anonymous-pull rate limits on shared GitHub runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)